### PR TITLE
docs(dreamcode): prompt default to CAPI

### DIFF
--- a/dreamcode.md
+++ b/dreamcode.md
@@ -23,9 +23,6 @@ import {
 
 const copilotExtension = new CopilotExtension({
   agent: "my-app-name",
-  prompt: {
-    defaultModel: "gpt-4o",
-  },
 });
 
 copilotExtension.on(
@@ -79,7 +76,7 @@ Regarding the context passed to event handlers
 
 - `message` / `confirmation` / etc are objects as received by the user
 - `octokit` is a pre-authenticated octokit instance
-- `prompt` is based on my work at https://github.com/github/gr2m-projects/blob/167/github-models/167-github-models/README.md. A simple API to interact with GitHub models.
+- `prompt` is based on my work at https://github.com/github/gr2m-projects/blob/167/github-models/167-github-models/README.md. A simple API to interact with GitHub models. I assume we will default the prompt URL to `https://api.githubcopilot.com/chat/completions` and the model to `gpt-4o` (or whatever our CAPI name for that is?)
 - `respond` is an API to send different types of responses to the user
 - `log` is the logger as we use it in Octokit. See https://github.com/octokit/core.js?tab=readme-ov-file#logging
 


### PR DESCRIPTION
Still not 100% about the difference between https://api.githubcopilot.com/chat/completions and https://models.inference.ai.azure.com/chat/completions, but I assume we will want to default the prompt base URL to https://api.githubcopilot.com/chat/completions and probably will set a default model name as well, that we prefer our users to use unless they know what they are doing