### PR TITLE
feat: `verifyRequestByKeyId()`, `verifyRequest()`, `fetchVerificationKeys()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ Verify the request payload using the provided signature and key. Note that the r
 ```js
 import { verify } from "@copilot-extensions/preview-sdk";
 
-const payloadIsVerified = await verify(request.body, signature, key);
+const payloadIsVerified = await verifyRequestPayload(
+  request.body,
+  signature,
+  key
+);
 // true or false
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ const payloadIsVerified = await verifyRequestByKeyId(
 
 ## API
 
+### `async verifyRequestByKeyId(rawBody, signature, keyId, options)`
+
+Verify the request payload using the provided signature and key ID. The method will request the public key from GitHub's API for the given keyId and then verify the payload.
+
+The `options` argument is optional. It can contain a `token` to authenticate the request to GitHub's API, or a custom `request` instance to use for the request.
+
+```js
+import { verifyRequestByKeyId } from "@copilot-extensions/preview-sdk";
+
+const payloadIsVerified = await verifyRequestByKeyId(
+  request.body,
+  signature,
+  key
+);
+
+// with token
+await verifyRequestByKeyId(request.body, signature, key, { token: "ghp_1234" });
+
+// with custom octokit request instance
+await verifyRequestByKeyId(request.body, signature, key, { request });
+```
+
 ### `async fetchVerificationKeys(options)`
 
 Fetches public keys for verifying copilot extension requests [from GitHub's API](https://api.github.com/meta/public_keys/copilot_api)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,50 @@
 
 ## Usage
 
-### `verify(rawBody, signature, keyId, options)`
+### Verify a request
+
+```js
+import { verifyRequestByKeyId } from "@copilot-extensions/preview-sdk";
+
+const payloadIsVerified = await verifyRequestByKeyId(
+  request.body,
+  signature,
+  key,
+  {
+    token: process.env.GITHUB_TOKEN,
+  }
+);
+// true or false
+```
+
+## API
+
+### `async fetchVerificationKeys(options)`
+
+Fetches public keys for verifying copilot extension requests [from GitHub's API](https://api.github.com/meta/public_keys/copilot_api)
+and returns them as an array. The request can be made without authentication, with a token, or with a custom [octokit request](https://github.com/octokit/request.js) instance.
+
+```js
+import { fetchVerificationKeys } from "@copilot-extensions/preview-sdk";
+
+// fetch without authentication
+const [current] = await fetchVerificationKeys();
+
+// with token
+const [current] = await fetchVerificationKeys({ token: "ghp_1234" });
+
+// with custom octokit request instance
+const [current] = await fetchVerificationKeys({ request });)
+```
+
+### `async verifyRequestPayload(rawBody, signature, keyId)`
+
+Verify the request payload using the provided signature and key. Note that the raw body as received by GitHub must be passed, before any parsing.
 
 ```js
 import { verify } from "@copilot-extensions/preview-sdk";
 
-const payloadIsVerified = await verify(request.body, signature, keyId, {
-  token,
-});
+const payloadIsVerified = await verify(request.body, signature, key);
 // true or false
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,27 @@ type RequestOptions = {
   request?: RequestInterface;
   token?: string;
 };
+export type VerificationPublicKey = {
+  key_identifier: string;
+  key: string;
+  is_current: boolean;
+};
 
-interface VerifyInterface {
+interface VerifyRequestInterface {
+  (
+    rawBody: string,
+    signature: string,
+    key: string
+  ): Promise<boolean>;
+}
+
+interface FetchVerificationKeysInterface {
+  (
+    requestOptions?: RequestOptions,
+  ): Promise<VerificationPublicKey[]>;
+}
+
+interface VerifyRequestByKeyIdInterface {
   (
     rawBody: string,
     signature: string,
@@ -15,4 +34,6 @@ interface VerifyInterface {
   ): Promise<boolean>;
 }
 
-export declare const verify: VerifyInterface;
+export declare const verifyRequest: VerifyRequestInterface;
+export declare const fetchVerificationKeys: FetchVerificationKeysInterface;
+export declare const verifyRequestByKeyId: VerifyRequestByKeyIdInterface;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,32 +1,66 @@
 import { expectType } from "tsd";
 import { request } from "@octokit/request";
 
-import { verify } from "./index.js";
+import {
+  fetchVerificationKeys,
+  verifyRequest,
+  verifyRequestByKeyId,
+  type VerificationPublicKey,
+} from "./index.js";
 
 const rawBody = "";
 const signature = "";
 const keyId = "";
+const key = ""
 const token = "";
 
-export async function verifyTest() {
-  const result = await verify(rawBody, signature, keyId);
+export async function verifyRequestByKeyIdTest() {
+  const result = await verifyRequestByKeyId(rawBody, signature, keyId);
   expectType<boolean>(result);
 
   // @ts-expect-error - first 3 arguments are required
-  verify(rawBody, signature);
+  verifyRequestByKeyId(rawBody, signature);
 
   // @ts-expect-error - rawBody must be a string
-  await verify(1, signature, keyId);
+  await verifyRequestByKeyId(1, signature, keyId);
 
   // @ts-expect-error - signature must be a string
-  await verify(rawBody, 1, keyId);
+  await verifyRequestByKeyId(rawBody, 1, keyId);
 
   // @ts-expect-error - keyId must be a string
-  await verify(rawBody, signature, 1);
+  await verifyRequestByKeyId(rawBody, signature, 1);
 
   // accepts a token argument
-  await verify(rawBody, signature, keyId, { token });
+  await verifyRequestByKeyId(rawBody, signature, keyId, { token });
 
   // accepts a request argument
-  await verify(rawBody, signature, keyId, { request });
+  await verifyRequestByKeyId(rawBody, signature, keyId, { request });
+}
+
+export async function verifyRequestTest() {
+  const result = await verifyRequest(rawBody, signature, key);
+  expectType<boolean>(result);
+
+  // @ts-expect-error - first 3 arguments are required
+  verifyRequest(rawBody, signature);
+
+  // @ts-expect-error - rawBody must be a string
+  await verifyRequest(1, signature, key);
+
+  // @ts-expect-error - signature must be a string
+  await verifyRequest(rawBody, 1, key);
+
+  // @ts-expect-error - key must be a string
+  await verifyRequest(rawBody, signature, 1);
+}
+
+export async function fetchVerificationKeysTest() {
+  const result = await fetchVerificationKeys();
+  expectType<VerificationPublicKey[]>(result);
+
+  // accepts a token argument
+  await fetchVerificationKeys({ token });
+
+  // accepts a request argument
+  await fetchVerificationKeys({ request });
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -4,7 +4,11 @@ import assert from "node:assert/strict";
 import { request as defaultRequest } from "@octokit/request";
 import { MockAgent } from "undici";
 
-import { verify } from "../index.js";
+import {
+  fetchVerificationKeys,
+  verifyRequest,
+  verifyRequestByKeyId,
+} from "../index.js";
 
 const RAW_BODY = `{"copilot_thread_id":"9a1cc23a-ab73-498b-87a5-96c94cb7e3f3","messages":[{"role":"user","content":"@gr2m hi","copilot_references":[{"type":"github.repository","data":{"type":"repository","id":102985470,"name":"sandbox","ownerLogin":"gr2m","ownerType":"User","readmePath":"README.md","description":"@gr2m's little sandbox to play","commitOID":"9b04fffccbb818b2e317394463731b66f1ec5e89","ref":"refs/heads/main","refInfo":{"name":"main","type":"branch"},"visibility":"public","languages":[{"name":"JavaScript","percent":100}]},"id":"gr2m/sandbox","is_implicit":false,"metadata":{"display_name":"gr2m/sandbox","display_icon":"","display_url":""}}],"copilot_confirmations":null},{"role":"user","content":"@gr2m test","copilot_references":[{"type":"github.repository","data":{"type":"repository","id":102985470,"name":"sandbox","ownerLogin":"gr2m","ownerType":"User","readmePath":"README.md","description":"@gr2m's little sandbox to play","commitOID":"9b04fffccbb818b2e317394463731b66f1ec5e89","ref":"refs/heads/main","refInfo":{"name":"main","type":"branch"},"visibility":"public","languages":[{"name":"JavaScript","percent":100}]},"id":"gr2m/sandbox","is_implicit":false,"metadata":{"display_name":"gr2m/sandbox","display_icon":"","display_url":""}}],"copilot_confirmations":null},{"role":"user","content":"@gr2m test","copilot_references":[{"type":"github.repository","data":{"type":"repository","id":102985470,"name":"sandbox","ownerLogin":"gr2m","ownerType":"User","readmePath":"README.md","description":"@gr2m's little sandbox to play","commitOID":"9b04fffccbb818b2e317394463731b66f1ec5e89","ref":"refs/heads/main","refInfo":{"name":"main","type":"branch"},"visibility":"public","languages":[{"name":"JavaScript","percent":100}]},"id":"gr2m/sandbox","is_implicit":false,"metadata":{"display_name":"gr2m/sandbox","display_icon":"","display_url":""}}],"copilot_confirmations":null},{"role":"user","content":"Current Date and Time (UTC): 2024-08-26 19:43:13\\nUser's Current URL: https://github.com/gr2m/sandbox\\nCurrent User's Login: gr2m\\n","name":"_session","copilot_references":[],"copilot_confirmations":null},{"role":"user","content":"","copilot_references":[{"type":"github.repository","data":{"type":"repository","id":102985470,"name":"sandbox","ownerLogin":"gr2m","ownerType":"User","readmePath":"README.md","description":"@gr2m's little sandbox to play","commitOID":"9b04fffccbb818b2e317394463731b66f1ec5e89","ref":"refs/heads/main","refInfo":{"name":"main","type":"branch"},"visibility":"public","languages":[{"name":"JavaScript","percent":100}]},"id":"gr2m/sandbox","is_implicit":false,"metadata":{"display_name":"gr2m/sandbox","display_icon":"","display_url":""}}],"copilot_confirmations":null},{"role":"user","content":"test","copilot_references":[],"copilot_confirmations":[]}],"stop":null,"top_p":0,"temperature":0,"max_tokens":0,"presence_penalty":0,"frequency_penalty":0,"copilot_skills":null,"agent":"gr2m"}`;
 const KEY_ID =
@@ -20,10 +24,10 @@ const SIGNATURE =
   "MEYCIQC8aEmkYA/4EQrXEOi2OL9nfpbnrCxkMc6HrH7b6SogKgIhAIYBThcpzkCCswiV1+pOaPI+zFQF9ShG61puoKs9rJjq";
 
 test("smoke", (t) => {
-  assert.equal(typeof verify, "function");
+  assert.equal(typeof verifyRequestByKeyId, "function");
 });
 
-test("minimal usage", async (t) => {
+test("verifyRequestByKeyId()", async (t) => {
   const mockAgent = new MockAgent();
   function fetchMock(url, opts) {
     opts ||= {};
@@ -54,67 +58,128 @@ test("minimal usage", async (t) => {
           "content-type": "application/json",
           "x-request-id": "<request-id>",
         },
-      },
+      }
     );
   const testRequest = defaultRequest.defaults({
     request: { fetch: fetchMock },
   });
 
-  const result = await verify(RAW_BODY, SIGNATURE, KEY_ID, {
+  const result = await verifyRequestByKeyId(RAW_BODY, SIGNATURE, KEY_ID, {
     request: testRequest,
   });
 
   assert.deepEqual(result, true);
 });
 
-test("invalid arguments", (t) => {
-  assert.rejects(verify(RAW_BODY, SIGNATURE), {
+test("verifyRequestByKeyId() - invalid arguments", (t) => {
+  assert.rejects(verifyRequestByKeyId(RAW_BODY, SIGNATURE), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid keyId",
   });
 
-  assert.rejects(verify("", SIGNATURE, KEY_ID), {
+  assert.rejects(verifyRequestByKeyId("", SIGNATURE, KEY_ID), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid payload",
   });
 
-  assert.rejects(verify(1, SIGNATURE, KEY_ID), {
+  assert.rejects(verifyRequestByKeyId(1, SIGNATURE, KEY_ID), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid payload",
   });
 
-  assert.rejects(verify(undefined, SIGNATURE, KEY_ID), {
+  assert.rejects(verifyRequestByKeyId(undefined, SIGNATURE, KEY_ID), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid payload",
   });
 
-  assert.rejects(verify(RAW_BODY, "", KEY_ID), {
+  assert.rejects(verifyRequestByKeyId(RAW_BODY, "", KEY_ID), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid signature",
   });
 
-  assert.rejects(verify(RAW_BODY, 1, KEY_ID), {
+  assert.rejects(verifyRequestByKeyId(RAW_BODY, 1, KEY_ID), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid signature",
   });
 
-  assert.rejects(verify(RAW_BODY, undefined, KEY_ID), {
+  assert.rejects(verifyRequestByKeyId(RAW_BODY, undefined, KEY_ID), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid signature",
   });
 
-  assert.rejects(verify(RAW_BODY, SIGNATURE, ""), {
+  assert.rejects(verifyRequestByKeyId(RAW_BODY, SIGNATURE, ""), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid keyId",
   });
 
-  assert.rejects(verify(RAW_BODY, SIGNATURE, 1), {
+  assert.rejects(verifyRequestByKeyId(RAW_BODY, SIGNATURE, 1), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid keyId",
   });
 
-  assert.rejects(verify(RAW_BODY, SIGNATURE, undefined), {
+  assert.rejects(verifyRequestByKeyId(RAW_BODY, SIGNATURE, undefined), {
     name: "Error",
     message: "[@copilot-extensions/preview-sdk] Invalid keyId",
   });
+});
+
+test("verifyRequest() - valid", async (t) => {
+  const result = await verifyRequest(RAW_BODY, SIGNATURE, CURRENT_PUBLIC_KEY);
+  assert.deepEqual(result, true);
+});
+
+test("verifyRequest() - invalid", async (t) => {
+  const result = await verifyRequest(RAW_BODY, SIGNATURE, "invalid-key");
+  assert.deepEqual(result, false);
+});
+
+test("fetchVerificationKeys()", async (t) => {
+  const mockAgent = new MockAgent();
+  function fetchMock(url, opts) {
+    opts ||= {};
+    opts.dispatcher = mockAgent;
+    return fetch(url, opts);
+  }
+
+  const publicKeys = [
+    {
+      key: "<key 1>",
+      key_identifier: "<key-id 1>",
+      is_current: true,
+    },
+    {
+      key: "<key 2>",
+      key_identifier: "<key-id 2>",
+      is_current: true,
+    },
+  ];
+
+  mockAgent.disableNetConnect();
+  const mockPool = mockAgent.get("https://api.github.com");
+  mockPool
+    .intercept({
+      method: "get",
+      path: `/meta/public_keys/copilot_api`,
+    })
+    .reply(
+      200,
+      {
+        public_keys: publicKeys,
+      },
+      {
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "<request-id>",
+        },
+      }
+    );
+  const testRequest = defaultRequest.defaults({
+    request: { fetch: fetchMock },
+  });
+
+  const result = await fetchVerificationKeys({
+    request: testRequest,
+  });
+
+  assert.deepEqual(result, publicKeys);
 });


### PR DESCRIPTION
BREAKING CHANGE: `verify()` method has been replaced by `verifyRequestByKeyId()` for clarity

Before:

```js
import { verify } from "@copilot-extensions/preview-sdk";
const payloadIsVerified = await verify(request.body, signature, keyId, { token });
```

After

```js
import { verifyRequestByKeyId } from "@copilot-extensions/preview-sdk";
const payloadIsVerified = await verifyRequestByKeyId(request.body, signature, key, { token });
```
