### PR TITLE
Fixing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export default handler(request, response) {
 }
 ```
 
-### Send a custom propmt
+### Send a custom prompt
 
 ```js
 import { prompt } from "@copilot-extensions/preview-sdk";
@@ -184,7 +184,7 @@ Send a list of references to the chat UI. The `references` argument must be an a
 
 The following properties are optional
 
-- `data`: object with any properties.
+- `data`: object with any properties
 - `is_implicit`: a boolean
 - `metadata`: an object with a required `display_name` and the optional properties: `display_icon` and `display_url`
 


### PR DESCRIPTION
This pull request includes minor updates to the `README.md` file to fix a typo and improve the consistency of the documentation.

Documentation updates:

* Corrected a typo in the section heading from "Send a custom propmt" to "Send a custom prompt". (`README.md`)
* Removed an unnecessary period at the end of the `data` property description for consistency. (`README.md`)