### PR TITLE
docs(`README.md`): point to `CONTRIBUTING.md` at root of directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ While implementing the lower-level functionality, we also dream big: what would 
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md)
+Please see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

This updates the README's reference to the CONTRIBUTING.md file to the correct location at root, rather than its previous location in `.github/CONTRIBUTING.md`.