### PR TITLE
docs(CONTRIBUTING.md): use the name of this project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for considering to contribute to `github-project` 💖
+Thank you for considering to contribute to `copilot-extensions/preview-sdk.js` 💖
 
 Please note that this project is released with a [Contributor Code of Conduct](./CODE_OF_CONDUCT.md).
 By participating you agree to abide by its terms.


### PR DESCRIPTION
## Summary

Previously, the Contributing guide specified `github-project` as a reference to this project's name.

This PR updates the name to it's repository name with owner, `copilot-extensions/preview-sdk.js`.