### PR TITLE
test(parse): add test coverage when no copilot_confirmations present

### DIFF
--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -77,7 +77,7 @@ test("verifyAndParseRequest()", async (t) => {
           "content-type": "application/json",
           "x-request-id": "<request-id>",
         },
-      },
+      }
     );
   const testRequest = defaultRequest.defaults({
     request: { fetch: fetchMock },
@@ -132,6 +132,21 @@ test("getUserConfirmation()", (t) => {
       id: "some-confirmation-id",
       metadata: { someConfirmationMetadata: "value" },
     },
-    result,
+    result
   );
+});
+
+test("getUserConfirmation() with no copilot confirmations", (t) => {
+  const payload = {
+    messages: [
+      {
+        content: "Some previous message",
+      },
+      {
+        content: "Hello, world!",
+      },
+    ],
+  };
+  const result = getUserConfirmation(payload);
+  t.deepEqual(undefined, result);
 });


### PR DESCRIPTION
<!--
  This pull request template provides suggested sections for framing your work.
  You're welcome to change or remove headers if it doesn't fit your use case. :) 
-->

### What are you trying to accomplish?
Improve test coverage for `parse.js` file. Concretely for `getUserConfirmation()` method.

relates to https://github.com/copilot-extensions/preview-sdk.js/issues/87

