### PR TITLE
docs(README): add links to official Copilot Extensions documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,13 @@ if (functionCall) {
 }
 ```
 
+## Copilot Extensions Documentation
+- [Using Copilot Extensions](https://docs.github.com/en/copilot/using-github-copilot/using-extensions-to-integrate-external-tools-with-copilot-chat)
+- [About building Copilot Extensions](https://docs.github.com/en/copilot/building-copilot-extensions/about-building-copilot-extensions)
+- [Set up process](https://docs.github.com/en/copilot/building-copilot-extensions/setting-up-copilot-extensions)
+- [Communicating with the Copilot platform](https://docs.github.com/en/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-the-copilot-platform)
+- [Communicating with GitHub](https://docs.github.com/en/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github)
+
 ## Dreamcode
 
 While implementing the lower-level functionality, we also dream big: what would our dream SDK for Coplitot extensions look like? Please have a look and share your thoughts and ideas:

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ if (functionCall) {
 ```
 
 ## Copilot Extensions Documentation
+
 - [Using Copilot Extensions](https://docs.github.com/en/copilot/using-github-copilot/using-extensions-to-integrate-external-tools-with-copilot-chat)
 - [About building Copilot Extensions](https://docs.github.com/en/copilot/building-copilot-extensions/about-building-copilot-extensions)
 - [Set up process](https://docs.github.com/en/copilot/building-copilot-extensions/setting-up-copilot-extensions)


### PR DESCRIPTION
Adding links to general extension docs to the README.

### What are you trying to accomplish?

Give builders a pathway to Extension Builders docs if they want to learn more.

### What approach did you choose and why?

Links to docs in the footer.

### What should reviewers focus on?
Any specific docs pages we should/shouldn't be linking