### PR TITLE
refactor: reuse `createTextEvent()` in `createAckEvent()`

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -2,15 +2,7 @@
 
 /** @type {import('..').CreateAckEventInterface} */
 export function createAckEvent() {
-  const data = {
-    choices: [
-      {
-        index: 0,
-        delta: { content: ``, role: "assistant" },
-      },
-    ],
-  };
-  return `data: ${JSON.stringify(data)}\n\n`;
+  return createTextEvent("");
 }
 
 /** @type {import('..').CreateTextEventInterface} */


### PR DESCRIPTION
<!--
  This pull request template provides suggested sections for framing your work.
  You're welcome to change or remove headers if it doesn't fit your use case. :)
-->

### What are you trying to accomplish?

A refactoring opportunity: after reading `createAckEvent()` and `createTextEvent`'s definitions, I noticed that the only difference was that the former passes in an empty string for its content.

### What approach did you choose and why?

I chose to update the body to use `createTextEvent()` directly, passing an empty string for its `message` argument. Ran tests locally and in CI to verify this works 👍 

### What should reviewers focus on?

Nothing I haven't mentioned 😉 