### PR TITLE
fix(readme): add `await` to `prompt.stream` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Works the same way as `prompt()`, but resolves with a `stream` key instead of a 
 ```js
 import { prompt } from "@copilot-extensions/preview-sdk";
 
-const { requestId, stream } = prompt.stream("What is the capital of France?", {
+const { requestId, stream } = await prompt.stream("What is the capital of France?", {
   token: process.env.TOKEN,
 });
 


### PR DESCRIPTION

Adds a small change to the `README.md` file. The change updates the example code to use `await` with the `prompt.stream` method for proper asynchronous handling.

